### PR TITLE
Fix: verifySignature now compares the generated signature with the incoming request signature

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ async function verifySignature(request) {
     });
 
     // All we need is the signature component of the Authorization header
-    const [ , , , generatedSignature] = request.headers.get('Authorization').match(re);
+    const [ , , , generatedSignature] = signedRequest.headers.get('Authorization').match(re);
 
     if (signature !== generatedSignature) {
         throw new SignatureInvalidException();


### PR DESCRIPTION
Unless my eyes are deceiving me, I think this code was previously checking the generated signature against …the generated signature 😅

(Sidenote: thanks for this code & the accompanying blog post about it– it was super helpful for a similar task I'm trying to achieve with B2 & Cloudflare Workers)